### PR TITLE
HTTP and test environment dependencies up to date

### DIFF
--- a/MarvelApiClient/build.gradle
+++ b/MarvelApiClient/build.gradle
@@ -99,16 +99,24 @@ uploadArchives {
   }
 }
 
+sourceSets {
+  test {
+    output.resourcesDir = "build/classes/test/resources"
+  }
+}
 
 dependencies {
   def okHttpVersion = "3.6.0"
+  def retrofitVersion = "2.2.0"
 
-  testCompile "junit:junit:4.12"
+  testCompile group: 'junit', name: 'junit', version: '4.12'
   testCompile "org.mockito:mockito-all:1.9.5"
   testCompile "com.squareup.okhttp:mockwebserver:2.7.5"
   testCompile "commons-io:commons-io:2.5"
 
   compile "com.squareup.okhttp3:okhttp:$okHttpVersion"
-  compile "com.squareup.retrofit2:retrofit:2.2.0"
   compile "com.squareup.okhttp3:logging-interceptor:$okHttpVersion"
+  compile "com.squareup.retrofit2:retrofit:$retrofitVersion"
+  compile "com.squareup.retrofit2:converter-gson:$retrofitVersion"
+  compile "com.google.code.gson:gson:2.8.0"
 }

--- a/MarvelApiClient/build.gradle
+++ b/MarvelApiClient/build.gradle
@@ -101,13 +101,14 @@ uploadArchives {
 
 
 dependencies {
-  testCompile group: 'junit', name: 'junit', version: '4.11'
-  testCompile 'org.mockito:mockito-all:1.9.5'
-  testCompile 'com.squareup.okhttp:mockwebserver:2.5.0'
-  testCompile 'commons-io:commons-io:2.4'
+  def okHttpVersion = "3.6.0"
 
-  compile 'com.squareup.okhttp:okhttp:2.5.0'
-  compile 'com.squareup.retrofit:retrofit:2.0.0-beta2'
-  compile 'com.squareup.retrofit:converter-gson:2.0.0-beta2'
-  compile 'com.squareup.okhttp:logging-interceptor:2.6.0'
+  testCompile "junit:junit:4.12"
+  testCompile "org.mockito:mockito-all:1.9.5"
+  testCompile "com.squareup.okhttp:mockwebserver:2.7.5"
+  testCompile "commons-io:commons-io:2.5"
+
+  compile "com.squareup.okhttp3:okhttp:$okHttpVersion"
+  compile "com.squareup.retrofit2:retrofit:2.2.0"
+  compile "com.squareup.okhttp3:logging-interceptor:$okHttpVersion"
 }

--- a/MarvelApiClient/src/main/java/com/karumi/marvelapiclient/AuthInterceptor.java
+++ b/MarvelApiClient/src/main/java/com/karumi/marvelapiclient/AuthInterceptor.java
@@ -15,11 +15,11 @@
 
 package com.karumi.marvelapiclient;
 
-import com.squareup.okhttp.HttpUrl;
-import com.squareup.okhttp.Interceptor;
-import com.squareup.okhttp.Request;
-import com.squareup.okhttp.Response;
 import java.io.IOException;
+import okhttp3.HttpUrl;
+import okhttp3.Interceptor;
+import okhttp3.Request;
+import okhttp3.Response;
 
 class AuthInterceptor implements Interceptor {
   private static final String TIMESTAMP_KEY = "ts";
@@ -46,7 +46,7 @@ class AuthInterceptor implements Interceptor {
       e.printStackTrace();
     }
     Request request = chain.request();
-    HttpUrl url = request.httpUrl()
+    HttpUrl url = request.url()
         .newBuilder()
         .addQueryParameter(TIMESTAMP_KEY, timestamp)
         .addQueryParameter(APIKEY_KEY, publicKey)

--- a/MarvelApiClient/src/main/java/com/karumi/marvelapiclient/CharacterApiClient.java
+++ b/MarvelApiClient/src/main/java/com/karumi/marvelapiclient/CharacterApiClient.java
@@ -20,7 +20,7 @@ import com.karumi.marvelapiclient.model.CharactersDto;
 import com.karumi.marvelapiclient.model.CharactersQuery;
 import com.karumi.marvelapiclient.model.MarvelResponse;
 import java.util.Map;
-import retrofit.Call;
+import retrofit2.Call;
 
 /**
  * Retrieves Character information given a  {@link CharactersQuery} or some simple params like the

--- a/MarvelApiClient/src/main/java/com/karumi/marvelapiclient/CharacterApiRest.java
+++ b/MarvelApiClient/src/main/java/com/karumi/marvelapiclient/CharacterApiRest.java
@@ -18,10 +18,10 @@ package com.karumi.marvelapiclient;
 import com.karumi.marvelapiclient.model.CharactersDto;
 import com.karumi.marvelapiclient.model.MarvelResponse;
 import java.util.Map;
-import retrofit.Call;
-import retrofit.http.GET;
-import retrofit.http.Path;
-import retrofit.http.QueryMap;
+import retrofit2.Call;
+import retrofit2.http.GET;
+import retrofit2.http.Path;
+import retrofit2.http.QueryMap;
 
 public interface CharacterApiRest {
   @GET("characters") Call<MarvelResponse<CharactersDto>> getCharacters(

--- a/MarvelApiClient/src/main/java/com/karumi/marvelapiclient/ComicApiClient.java
+++ b/MarvelApiClient/src/main/java/com/karumi/marvelapiclient/ComicApiClient.java
@@ -20,7 +20,7 @@ import com.karumi.marvelapiclient.model.ComicsDto;
 import com.karumi.marvelapiclient.model.ComicsQuery;
 import com.karumi.marvelapiclient.model.MarvelResponse;
 import java.util.Map;
-import retrofit.Call;
+import retrofit2.Call;
 
 /**
  * Retrieves Comics information given a  {@link ComicsQuery} or some simple params like the

--- a/MarvelApiClient/src/main/java/com/karumi/marvelapiclient/ComicApiRest.java
+++ b/MarvelApiClient/src/main/java/com/karumi/marvelapiclient/ComicApiRest.java
@@ -15,14 +15,13 @@
 
 package com.karumi.marvelapiclient;
 
-import com.karumi.marvelapiclient.model.CharactersDto;
 import com.karumi.marvelapiclient.model.ComicsDto;
 import com.karumi.marvelapiclient.model.MarvelResponse;
 import java.util.Map;
-import retrofit.Call;
-import retrofit.http.GET;
-import retrofit.http.Path;
-import retrofit.http.QueryMap;
+import retrofit2.Call;
+import retrofit2.http.GET;
+import retrofit2.http.Path;
+import retrofit2.http.QueryMap;
 
 interface ComicApiRest {
   @GET("comics") Call<MarvelResponse<ComicsDto>> getComics(

--- a/MarvelApiClient/src/main/java/com/karumi/marvelapiclient/MarvelApiClient.java
+++ b/MarvelApiClient/src/main/java/com/karumi/marvelapiclient/MarvelApiClient.java
@@ -17,8 +17,8 @@ package com.karumi.marvelapiclient;
 
 import com.google.gson.Gson;
 import java.io.IOException;
-import retrofit.Call;
-import retrofit.Response;
+import retrofit2.Call;
+import retrofit2.Response;
 
 class MarvelApiClient {
   private static final int INVALID_AUTH_CODE = 401;
@@ -40,7 +40,7 @@ class MarvelApiClient {
     } catch (IOException e) {
       throw new MarvelApiException("Network error", e);
     }
-    if (response.isSuccess()) {
+    if (response.isSuccessful()) {
       return response.body();
     } else {
       parseError(response);

--- a/MarvelApiClient/src/main/java/com/karumi/marvelapiclient/MarvelApiConfig.java
+++ b/MarvelApiClient/src/main/java/com/karumi/marvelapiclient/MarvelApiConfig.java
@@ -15,10 +15,12 @@
 
 package com.karumi.marvelapiclient;
 
-import com.squareup.okhttp.OkHttpClient;
-import com.squareup.okhttp.logging.HttpLoggingInterceptor;
-import retrofit.GsonConverterFactory;
-import retrofit.Retrofit;
+import java.util.List;
+import okhttp3.Interceptor;
+import okhttp3.OkHttpClient;
+import okhttp3.logging.HttpLoggingInterceptor;
+import retrofit2.Retrofit;
+import retrofit2.converter.gson.GsonConverterFactory;
 
 /**
  * Api client for access to Marvel Api.
@@ -95,34 +97,27 @@ public class MarvelApiConfig {
 
     public MarvelApiConfig build() {
       if (retrofit == null) {
-        retrofit = createDefaultRetrofit(baseUrl, debug);
+        retrofit = buildRetrofit();
       }
-
-      addKeysToParams(retrofit, publicKey, privateKey, timeProvider);
 
       return new MarvelApiConfig(publicKey, privateKey, retrofit, debug);
     }
 
-    private void addKeysToParams(Retrofit retrofit, String publicKey, String privateKey,
-        TimeProvider timeProvider) {
-      OkHttpClient client = retrofit.client();
-      client.interceptors().add(new AuthInterceptor(publicKey, privateKey, timeProvider));
-    }
-
-    private Retrofit createDefaultRetrofit(String baseUrl, boolean debug) {
+    private Retrofit buildRetrofit() {
       OkHttpClient client = new OkHttpClient();
+      List<Interceptor> interceptors = client.interceptors();
       if (debug) {
         HttpLoggingInterceptor interceptor = new HttpLoggingInterceptor();
         interceptor.setLevel(HttpLoggingInterceptor.Level.BODY);
-        client.interceptors().add(interceptor);
+        interceptors.add(interceptor);
       }
 
-      Retrofit retrofit = new Retrofit.Builder().baseUrl(baseUrl)
+      interceptors.add(new AuthInterceptor(publicKey, privateKey, timeProvider));
+
+      return new Retrofit.Builder().baseUrl(baseUrl)
           .client(client)
           .addConverterFactory(GsonConverterFactory.create())
           .build();
-
-      return retrofit;
     }
   }
 }

--- a/MarvelApiClient/src/main/java/com/karumi/marvelapiclient/SeriesApiClient.java
+++ b/MarvelApiClient/src/main/java/com/karumi/marvelapiclient/SeriesApiClient.java
@@ -22,7 +22,7 @@ import com.karumi.marvelapiclient.model.SeriesCollectionDto;
 import com.karumi.marvelapiclient.model.SeriesDto;
 import com.karumi.marvelapiclient.model.SeriesQuery;
 import java.util.Map;
-import retrofit.Call;
+import retrofit2.Call;
 
 /**
  * Retrieves Series information given a  {@link SeriesQuery} or some simple params like the

--- a/MarvelApiClient/src/main/java/com/karumi/marvelapiclient/SeriesApiRest.java
+++ b/MarvelApiClient/src/main/java/com/karumi/marvelapiclient/SeriesApiRest.java
@@ -19,10 +19,10 @@ import com.karumi.marvelapiclient.model.ComicsDto;
 import com.karumi.marvelapiclient.model.MarvelResponse;
 import com.karumi.marvelapiclient.model.SeriesCollectionDto;
 import java.util.Map;
-import retrofit.Call;
-import retrofit.http.GET;
-import retrofit.http.Path;
-import retrofit.http.QueryMap;
+import retrofit2.Call;
+import retrofit2.http.GET;
+import retrofit2.http.Path;
+import retrofit2.http.QueryMap;
 
 interface SeriesApiRest {
   @GET("series") Call<MarvelResponse<SeriesCollectionDto>> getSeries(

--- a/MarvelApiClient/src/main/java/com/karumi/marvelapiclient/model/ComicDto.java
+++ b/MarvelApiClient/src/main/java/com/karumi/marvelapiclient/model/ComicDto.java
@@ -14,7 +14,6 @@
  */
 
 package com.karumi.marvelapiclient.model;
-
 import com.google.gson.annotations.SerializedName;
 import java.util.List;
 

--- a/MarvelApiClient/src/main/java/com/karumi/marvelapiclient/model/MarvelCollection.java
+++ b/MarvelApiClient/src/main/java/com/karumi/marvelapiclient/model/MarvelCollection.java
@@ -45,5 +45,4 @@ public class MarvelCollection<T> {
   protected List<T> getResults() {
     return results;
   }
-
 }

--- a/MarvelApiClient/src/test/java/com/karumi/marvelapiclient/ApiClientTest.java
+++ b/MarvelApiClient/src/test/java/com/karumi/marvelapiclient/ApiClientTest.java
@@ -15,18 +15,21 @@
 
 package com.karumi.marvelapiclient;
 
+import com.karumi.marvelapiclient.extensions.FileExtensions;
 import com.karumi.marvelapiclient.model.MarvelResponse;
+import com.squareup.okhttp.mockwebserver.MockResponse;
 import com.squareup.okhttp.mockwebserver.MockWebServer;
-import java.io.File;
+import com.squareup.okhttp.mockwebserver.RecordedRequest;
 import java.io.IOException;
-import java.util.List;
-import org.apache.commons.io.FileUtils;
+import org.hamcrest.core.StringContains;
 import org.junit.After;
+import org.junit.Assert;
 import org.junit.Before;
 import org.mockito.MockitoAnnotations;
 
+import static org.junit.Assert.assertEquals;
+
 public class ApiClientTest {
-  private static final String FILE_ENCODING = "UTF-8";
   protected static final String ANY_TIME_ZONE = "PST";
   private static final int OK_CODE = 200;
 
@@ -48,7 +51,7 @@ public class ApiClientTest {
   }
 
   protected void enqueueMockResponse(int code) throws IOException {
-    enqueueMockResponse(OK_CODE, "{}");
+    enqueueMockResponse(code, "{}");
   }
 
   protected void enqueueMockResponse(int code, String response) throws IOException {
@@ -59,10 +62,11 @@ public class ApiClientTest {
   }
 
   protected void enqueueMockResponse(String fileName) throws IOException {
-    MockResponse mockResponse = new MockResponse();
-    String fileContent = getContentFromFile(fileName);
-    mockResponse.setBody(fileContent);
-    server.enqueue(mockResponse);
+    String body = FileExtensions.getStringFromFile(getClass(), fileName);
+    MockResponse response = new MockResponse();
+    response.setResponseCode(OK_CODE);
+    response.setBody(body);
+    server.enqueue(response);
   }
 
   protected void assertRequestSentTo(String url) throws InterruptedException {
@@ -74,7 +78,7 @@ public class ApiClientTest {
     RecordedRequest request = server.takeRequest();
 
     for (String path : paths) {
-      Assert.assertThat(request.getPath(), containsString(path));
+      Assert.assertThat(request.getPath(), StringContains.containsString(path));
     }
   }
 
@@ -90,16 +94,5 @@ public class ApiClientTest {
 
   protected String getBaseEndpoint() {
     return server.getUrl("/").toString();
-  }
-
-  private String getContentFromFile(String fileName) throws IOException {
-    fileName = getClass().getResource("/" + fileName).getFile();
-    File file = new File(fileName);
-    List<String> lines = FileUtils.readLines(file, FILE_ENCODING);
-    StringBuilder stringBuilder = new StringBuilder();
-    for (String line : lines) {
-      stringBuilder.append(line);
-    }
-    return stringBuilder.toString();
   }
 }

--- a/MarvelApiClient/src/test/java/com/karumi/marvelapiclient/ApiClientTest.java
+++ b/MarvelApiClient/src/test/java/com/karumi/marvelapiclient/ApiClientTest.java
@@ -16,20 +16,14 @@
 package com.karumi.marvelapiclient;
 
 import com.karumi.marvelapiclient.model.MarvelResponse;
-import com.squareup.okhttp.mockwebserver.MockResponse;
 import com.squareup.okhttp.mockwebserver.MockWebServer;
-import com.squareup.okhttp.mockwebserver.RecordedRequest;
 import java.io.File;
 import java.io.IOException;
 import java.util.List;
 import org.apache.commons.io.FileUtils;
 import org.junit.After;
-import org.junit.Assert;
 import org.junit.Before;
 import org.mockito.MockitoAnnotations;
-
-import static junit.framework.Assert.assertEquals;
-import static org.hamcrest.core.StringContains.containsString;
 
 public class ApiClientTest {
   private static final String FILE_ENCODING = "UTF-8";

--- a/MarvelApiClient/src/test/java/com/karumi/marvelapiclient/CharacterApiClientTest.java
+++ b/MarvelApiClient/src/test/java/com/karumi/marvelapiclient/CharacterApiClientTest.java
@@ -31,8 +31,8 @@ import java.util.Date;
 import java.util.List;
 import java.util.TimeZone;
 import org.junit.Test;
-import retrofit.GsonConverterFactory;
-import retrofit.Retrofit;
+import retrofit2.Retrofit;
+import retrofit2.converter.gson.GsonConverterFactory;
 
 import static org.junit.Assert.assertEquals;
 
@@ -179,7 +179,6 @@ public class CharacterApiClientTest extends ApiClientTest {
   }
 
   private CharacterApiClient givenCharacterApiClient() {
-
     Retrofit retrofit = new Retrofit.Builder().baseUrl(getBaseEndpoint())
         .addConverterFactory(GsonConverterFactory.create())
         .build();

--- a/MarvelApiClient/src/test/java/com/karumi/marvelapiclient/ComicApiClientTest.java
+++ b/MarvelApiClient/src/test/java/com/karumi/marvelapiclient/ComicApiClientTest.java
@@ -38,8 +38,8 @@ import java.util.Date;
 import java.util.List;
 import java.util.TimeZone;
 import org.junit.Test;
-import retrofit.GsonConverterFactory;
-import retrofit.Retrofit;
+import retrofit2.Retrofit;
+import retrofit2.converter.gson.GsonConverterFactory;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;
@@ -228,7 +228,6 @@ public class ComicApiClientTest extends ApiClientTest {
   }
 
   private ComicApiClient givenComicApiClient() {
-
     Retrofit retrofit = new Retrofit.Builder().baseUrl(getBaseEndpoint())
         .addConverterFactory(GsonConverterFactory.create())
         .build();

--- a/MarvelApiClient/src/test/java/com/karumi/marvelapiclient/SeriesApiClientTest.java
+++ b/MarvelApiClient/src/test/java/com/karumi/marvelapiclient/SeriesApiClientTest.java
@@ -36,8 +36,8 @@ import java.util.Date;
 import java.util.List;
 import java.util.TimeZone;
 import org.junit.Test;
-import retrofit.GsonConverterFactory;
-import retrofit.Retrofit;
+import retrofit2.Retrofit;
+import retrofit2.converter.gson.GsonConverterFactory;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;
@@ -276,7 +276,6 @@ public class SeriesApiClientTest extends ApiClientTest {
   }
 
   private SeriesApiClient givenSeriesApiClient() {
-
     Retrofit retrofit = new Retrofit.Builder().baseUrl(getBaseEndpoint())
         .addConverterFactory(GsonConverterFactory.create())
         .build();

--- a/MarvelApiClient/src/test/java/com/karumi/marvelapiclient/extensions/FileExtensions.java
+++ b/MarvelApiClient/src/test/java/com/karumi/marvelapiclient/extensions/FileExtensions.java
@@ -1,0 +1,23 @@
+package com.karumi.marvelapiclient.extensions;
+
+import java.io.File;
+import java.io.IOException;
+import org.apache.commons.io.FileUtils;
+
+/**
+ * Used to extend file functionality with new methods like the one to read from a file and parse
+ * it to a string.
+ */
+public final class FileExtensions {
+
+  private static final String UTF_8 = "UTF-8";
+
+  private FileExtensions() {
+  }
+
+  public static String getStringFromFile(Class clazz, String filePath) throws IOException {
+    ClassLoader classLoader = clazz.getClassLoader();
+    File file = new File(classLoader.getResource("resources/" + filePath).getFile());
+    return FileUtils.readFileToString(file, UTF_8);
+  }
+}

--- a/MarvelApiClient/src/test/java/com/karumi/marvelapiclient/model/CharactersQueryTest.java
+++ b/MarvelApiClient/src/test/java/com/karumi/marvelapiclient/model/CharactersQueryTest.java
@@ -38,7 +38,7 @@ public class CharactersQueryTest {
   }
 
   @Test(expected = IllegalArgumentException.class)
-     public void shouldThrowExceptionWhenAddNullComics() throws Exception {
+  public void shouldThrowExceptionWhenAddNullComics() throws Exception {
     CharactersQuery.Builder.create().addComics(null).build();
   }
 

--- a/sample/build.gradle
+++ b/sample/build.gradle
@@ -22,6 +22,6 @@ repositories {
 }
 
 dependencies {
-    testCompile group: 'junit', name: 'junit', version: '4.11'
+    testCompile group: 'junit', name: 'junit', version: '4.12'
     compile project(':MarvelApiClient')
 }


### PR DESCRIPTION
### Rationale

I was just about to start using your client for a sample project and found that it was so out of date and using many old library versions. Would be ❤️ If you can have this merged and deployed to maven central in a new version at some point.

### Work done
* Upgraded the following dependencies:
  * Junit 4.11 -> 4.12
  * MockWebServer 2.5.0 -> 2.7.5 .
  * apache commons-io 2.4 -> 2.5
  * OkHttp 2.5.0 -> 3.6.0
  * Retrofit 2.0.0-beta2 -> 2.2.0
  * Retrofit gson converter 2.0.0-beta2 -> 2.2.0
  * OkHttp logging interceptor 2.6.0 -> 3.6.0

* Updated sources (main and tests ones) to match new library requirements.

### Hints
I needed to add the following lines to the library `build.gradle` file in order to copy test resources to the proper folder:
```groovy
sourceSets {
  test {
    output.resourcesDir = "build/classes/test/resources"
  }
}
```
For some reason, test resources where not being properly copied by default and some tests where failing with null pointer exceptions. Android studio still is not copying the resources by itself when I run tests using the IDE (not sure about why tbh). But yeah, tests are passing when I run them using the gradle console: `./gradlew :MarvelApiClient:test`. 

I hope that's enough.
