### PR TITLE
Switch the BASE_URL to HTTPS

### DIFF
--- a/MarvelApiClient/src/main/java/com/karumi/marvelapiclient/MarvelApiConfig.java
+++ b/MarvelApiClient/src/main/java/com/karumi/marvelapiclient/MarvelApiConfig.java
@@ -54,7 +54,7 @@ public class MarvelApiConfig {
    */
   @SuppressWarnings("UnusedDeclaration") public static class Builder {
 
-    private static final String MARVEL_API_BASE_URL = "http://gateway.marvel.com/v1/public/";
+    private static final String MARVEL_API_BASE_URL = "https://gateway.marvel.com/v1/public/";
     private final String privateKey;
     private final String publicKey;
     private boolean debug;

--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ MarvelApiConfig marvelApiConfig = new MarvelApiConfig.Builder(publicKey, private
 
 Once you have configured your Marvel api, you can use this object to obtain information from the Marvel Api.
 
-###Characters Api
+### Characters Api
 
 ``CharacterApiClient`` contains all operations used to retrieve characters from the Marvel Api. If you want to perform complex queries you can use ``CharactersQuery`` object.
 
@@ -29,7 +29,7 @@ CharactersQuery spider = CharactersQuery.Builder.create().withOffset(0).withLimi
 MarvelResponse<CharactersDto> all = characterApiClient.getAll(spider);
 ```
 
-###Comics Api
+### Comics Api
 
 ``ComicApiClient`` contains all operations used to retrieve comics from the Marvel Api. If you want to perform complex queries you can use ``ComicsQuery`` object.
 
@@ -39,7 +39,7 @@ ComicsQuery query = ComicsQuery.Builder.create().withOffset(0).withLimit(10).bui
 MarvelResponse<ComicsDto> all = comicApiClient.getAll(query);
 ```
 
-###Series Api
+### Series Api
 
 ``SeriesApiClient`` contains all operations used to retrieve series from the Marvel Api. If you want to perform complex queries you can use ``SeriesQuery`` object.
 

--- a/README.md
+++ b/README.md
@@ -56,7 +56,7 @@ Include the library in your ``build.gradle``
 
 ```groovy
 dependencies{
-    compile 'com.karumi:marvelapiclient:0.0.4'
+    compile 'com.karumi:marvelapiclient:1.0.1'
 }
 ```
 
@@ -66,7 +66,7 @@ or to your ``pom.xml`` if you are using Maven
 <dependency>
     <groupId>com.karumi</groupId>
     <artifactId>marvelapiclient</artifactId>
-    <version>0.0.4</version>
+    <version>1.0.1</version>
     <type>jar</type>
 </dependency>
 


### PR DESCRIPTION
Other than being safer HTTPS is [required by Android Pie](https://android-developers.googleblog.com/2018/04/protecting-users-with-tls-by-default-in.html).

HTTP is still possible but it requires extra work. Since the Marvel API supports HTTPS, why not use it.

I also updated the README (spaces are required after ### to render properly as subheading).
Also updated the gradle/maven artifact ID to point the the latest available version. 